### PR TITLE
Fix up careless macro invocations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "archetype"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 license = "MIT"
-description = "Record all the briliance in your life."
+description = "Lightweight golden testing library."
 
 [dependencies]
 paste = "1.0.14"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,9 @@ use similar::{ChangeTag, TextDiff};
 use std::fs;
 use std::path::PathBuf;
 
+#[doc(hidden)]
+pub use paste::paste;
+
 /// Take a snapshot of a some UTF-8 encoded text under a file with the
 /// name `key`.
 ///
@@ -25,7 +28,7 @@ use std::path::PathBuf;
 /// ```
 pub fn snap(key: &str, subject: String) {
     let path = {
-        let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let mut dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
         dir.push("snapshots");
         if !dir.exists() {
             std::fs::create_dir_all(&dir).ok();
@@ -109,10 +112,10 @@ pub fn snap_json<A: Serialize>(key: &str, subject: &A) {
 #[macro_export]
 macro_rules! snap_json_test {
     ($fixture:ident) => {
-        paste::paste! {
+        $crate::paste! {
             #[test]
             fn [<snapshot_$fixture>]() {
-                crate::snap_json(std::stringify!($fixture), &$fixture());
+                $crate::snap_json(std::stringify!($fixture), &$fixture());
             }
         }
     };


### PR DESCRIPTION
This resolves paste as an export from archetype itself, but hides it from the docs; it's not part of our actual public interface, it is only incidental in getting the test macro to work.

Also, the `env!` call would point to the wrong location, and instead needed to be `std::env:var` which is trusted to always exist from cargo, hence the unwrap.